### PR TITLE
Change format of ReadMe to be syntactically correct

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
 # Deloton-Project
 
 ## Table of contents
-* [General Info](#general-info)
-* [Technologies](#technologies)
-* [Setup](#setup)
-* [Credits](#credits)
-* [Legacy Contributions](#legacy-contributions)
+
+- [General Info](#general-info)
+- [Technologies](#technologies)
+- [Setup](#setup)
+- [Credits](#credits)
+- [Legacy Contributions](#legacy-contributions)
 
 ## General Info
+
 Creation of a full ETL pipeline whereby data collected from live bike usage outputs meaningful and insightful forms of data visualisation and functionality.
 These take the form of:
+
 - Real-time dashboard display of current user ride and recent history
 - Automated email service for excessively high heart rate data
 - Long term storage of user data for prospective business analysis
@@ -18,17 +21,22 @@ These take the form of:
 - Tableau integration to perform data querying and dashboard creation
 
 ## Technologies
+
 blah
 
 ## Setup
+
 blah
 
 ## Credits
+
 Direct contributors to the repository:
-* Seb Shaw: [sebjshaw](https://github.com/sebjshaw)
-* Dominic Lawson: [DomLaw82](https://github.com/DomLaw82)
-* Alexander Skowronski: [AlexSkowronski2](https://github.com/AlexSkowronski2)
+
+- Seb Shaw: [sebjshaw](https://github.com/sebjshaw)
+- Dominic Lawson: [DomLaw82](https://github.com/DomLaw82)
+- Alexander Skowronski: [AlexSkowronski2](https://github.com/AlexSkowronski2)
 
 ## Legacy Contributions
+
 Welcome to the first edit - Alex
 Another edit - this time Seb


### PR DESCRIPTION
No content added to the ReadMe.

Changed the formatting to remove the yellow lines in VSCode. 

- Changed the '-' to '*' for bullet points 
- Added white space either side of the titles 
- Added white space either side of the unordered lists