### PR TITLE
cache fix

### DIFF
--- a/ec2-dash/cache.py
+++ b/ec2-dash/cache.py
@@ -22,4 +22,4 @@ def set_cache_value(email: str) -> None:
 	Args:
 			email (str): user email
 	"""
-	redisClient.set(email, True, ex=15)
+	redisClient.set(email, 'True', ex=15)


### PR DESCRIPTION
Hotfix for local redis cache, value cannot be type bool, so changed to string