### PR TITLE
Interrupted ride changes

### DIFF
--- a/ec2-dash/dash_sqlite.py
+++ b/ec2-dash/dash_sqlite.py
@@ -8,6 +8,7 @@ from datetime import datetime
 import cache
 
 FEB_1_2023_SECS = datetime.strptime('2023-02-01 00:00:00', '%Y-%m-%d %H:%M:%S') #the first of Feb as a datetime object
+NOW = datetime.now() #the second the program is initialised as a datetime object. For the ride_id of the interrupted ride
 
 # create a boto3 client for when the csv needs to be uplaoded to the s3 bucket
 s3 = boto3.client('s3')
@@ -154,7 +155,7 @@ def push_csv_files_to_s3():
 
 if __name__ == "__main__":
     recreate_current_ride_table(cursor, conn) #creates a table for the current ride data to be inserted into 
-    ride_id = 'N/A' #placeholder for ride_id until user info is received
+    ride_id = str((NOW - FEB_1_2023_SECS).total_seconds())[:-6] #ride_id of interrupted ride is assigned now as start time 
     ride_date = 'N/A' #placeholder until user info is received
     max_hr = 220
     user_info = 'N/A' #placeholder until user info is received

--- a/ec2-dash/dash_sqlite.py
+++ b/ec2-dash/dash_sqlite.py
@@ -159,6 +159,7 @@ if __name__ == "__main__":
     ride_date = 'N/A' #placeholder until user info is received
     max_hr = 220
     user_info = 'N/A' #placeholder until user info is received
+    user_id = 0000
     
     # constantly retrieving logs and creating tables and csvs
     while True:
@@ -184,15 +185,13 @@ if __name__ == "__main__":
                 # regenerate the ride_id, user_id and ride_date
                 ride_id = recreate_ride_id_from_datetime(log_entry)
                 user_info = log_entry
+                user_id = log_entry['user_id']
                 ride_date = log_entry['date'] + " " + log_entry['time']
                 
             # only adds to the database if it is a full entry      
             if len(log_entry) == 7:
-                # if no user_info, N/A is added as the user_id
-                try:
-                    add_entry_to_table(cursor, conn, log_entry, ride_id, user_info['user_id'])
-                except:
-                    add_entry_to_table(cursor, conn, log_entry, ride_id, 'N/A')
+                # adds entry to the table, user_id initially 0000 unless user_info has been received
+                add_entry_to_table(cursor, conn, log_entry, ride_id, user_id)
                 if compare_hr_to_max_hr(log_entry['heart_rate'], max_hr) == True and cache.check_cache_value(user_info['email_address']) is None:
                     cache.set_cache_value(user_info['email_address'])
                     user_email_dict = create_dict_for_email(user_info, int(log_entry['heart_rate']), max_hr, log_entry['date'], int(log_entry['duration'][:-2]))


### PR DESCRIPTION
Before:
- ride_id and user_id of interrupted ride were set to 'N/A' in the we would be able to go back through the kafka topic and retrieve the user_info for the ride. Can't find a way to do this without committing the offset of the consumer and in this case it wouldn't work as the consumer is turned off all night so in the morning we would wake up to a log a second for 10 hours. Useless

After:
- ride_id is now assigned assuming the ride started the second the consumer was initialised (not strictly true but gives a unique id nontheless)
- user_id is set to `0000` until user information is received upon which it is changed to the new user id 