### PR TITLE
Move run_files.sh into root directory of repo

### DIFF
--- a/ec2/run_files.sh
+++ b/ec2/run_files.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash 
-python ingestion/dash_sqlite.py & python dash/app.py

--- a/run_files.sh
+++ b/run_files.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash 
+python ec2/ingestion/dash_sqlite.py & python ec2/dash/app.py


### PR DESCRIPTION
Move bash file into the root directory of the repo. Means the paths in the dash folder functions work properly.