### PR TITLE
Remove cache. Allows consumer to continue when email sent

### DIFF
--- a/daily_report/create_report/docker_to_ecr.sh
+++ b/daily_report/create_report/docker_to_ecr.sh
@@ -1,4 +1,4 @@
 aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin 605126261673.dkr.ecr.eu-west-2.amazonaws.com
 docker tag create_report 605126261673.dkr.ecr.eu-west-2.amazonaws.com/three-musketeers:create_report
 docker push 605126261673.dkr.ecr.eu-west-2.amazonaws.com/three-musketeers:create_report
-aws lambda update-function-code --function-name Three-M_Create-Report --image-uri 605126261673.dkr.ecr.eu-west-2.amazonaws.com/three-musketeers:create_report
+aws lambda update-function-code --function-name Three-M-Create-Report --image-uri 605126261673.dkr.ecr.eu-west-2.amazonaws.com/three-musketeers:create_report

--- a/ec2/ingestion/dash_sqlite.py
+++ b/ec2/ingestion/dash_sqlite.py
@@ -213,8 +213,9 @@ if __name__ == "__main__":
             if len(log_entry) == 7:
                 # adds entry to the table, user_id initially 0000 unless user_info has been received
                 add_entry_to_table(cursor, conn, log_entry, ride_id, user_id)
-                if compare_hr_to_max_hr(log_entry['heart_rate'], max_hr) == True and cache.check_cache_value(user_info['email_address']) is None:
-                    cache.set_cache_value(user_info['email_address'])
+                if compare_hr_to_max_hr(log_entry['heart_rate'], max_hr) == True: 
+                # and cache.check_cache_value(user_info['email_address']) is None:
+                    # cache.set_cache_value(user_info['email_address'])
                     user_email_dict = create_dict_for_email(user_info, int(log_entry['heart_rate']), max_hr, log_entry['date'], int(log_entry['duration'][:-2]))
                     send_user_hr_warning(user_email_dict)
                     os.environ['TOTAL_HR_EMAILS'] += 1

--- a/ec2/ingestion/dash_sqlite.py
+++ b/ec2/ingestion/dash_sqlite.py
@@ -218,7 +218,9 @@ if __name__ == "__main__":
                     # cache.set_cache_value(user_info['email_address'])
                     user_email_dict = create_dict_for_email(user_info, int(log_entry['heart_rate']), max_hr, log_entry['date'], int(log_entry['duration'][:-2]))
                     send_user_hr_warning(user_email_dict)
-                    os.environ['TOTAL_HR_EMAILS'] += 1
+                    total_emails = int(os.environ['TOTAL_HR_EMAILS']) + 1
+                    os.environ['TOTAL_HR_EMAILS'] = str(total_emails)
+                    
                     
         except KeyboardInterrupt:
             pass

--- a/ec2/ingestion/dash_sqlite.py
+++ b/ec2/ingestion/dash_sqlite.py
@@ -213,9 +213,8 @@ if __name__ == "__main__":
             if len(log_entry) == 7:
                 # adds entry to the table, user_id initially 0000 unless user_info has been received
                 add_entry_to_table(cursor, conn, log_entry, ride_id, user_id)
-                if compare_hr_to_max_hr(log_entry['heart_rate'], max_hr) == True: 
-                # and cache.check_cache_value(user_info['email_address']) is None:
-                    # cache.set_cache_value(user_info['email_address'])
+                if compare_hr_to_max_hr(log_entry['heart_rate'], max_hr) == True and cache.check_cache_value(user_info['email_address']) is None:
+                    cache.set_cache_value(user_info['email_address'])
                     user_email_dict = create_dict_for_email(user_info, int(log_entry['heart_rate']), max_hr, log_entry['date'], int(log_entry['duration'][:-2]))
                     send_user_hr_warning(user_email_dict)
                     total_emails = int(os.environ['TOTAL_HR_EMAILS']) + 1


### PR DESCRIPTION
Consumer stopped when heart rate went too high. Was working before the cache was added so removing the cache to enable the consumer to continue running after email sent 